### PR TITLE
Fix preloader repeated execution

### DIFF
--- a/assests/js/script.js
+++ b/assests/js/script.js
@@ -73,9 +73,11 @@ function loader(){
     document.querySelector('.loader-container').classList.add('fade-out');
 }
 function fadeOut(){
-    setInterval(loader,500);
+    // use a one-time timeout instead of an interval to avoid repeatedly
+    // querying the DOM and re-adding the class after it has been applied
+    setTimeout(loader,500);
 }
-window.onload = fadeOut;
+window.addEventListener('load', fadeOut);
 // pre loader end
 
 // disable developer mode


### PR DESCRIPTION
## Summary
- prevent infinite preloader timer by using a one-time timeout
- hook preloader fade-out on window load via event listener

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689973f2d0c88324a0aba7747cb8e62e