### PR TITLE
feat: display blog posts from GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ If you want to contact me, you can reach me through below handles.
 &nbsp;&nbsp;<a href="https://www.linkedin.com/in/samandeep-singh-tomar-01761a205"><img src="https://www.felberpr.com/wp-content/uploads/linkedin-logo.png" width="30"></img></a>
 
 © 2021 Samandeep Singh Tomar
+
+### Blog posts
+Blog entries on the site are sourced from this repository's GitHub issues labeled `blog`. Create a new issue with that label and its title and body will automatically appear in the blog section.

--- a/assests/js/script.js
+++ b/assests/js/script.js
@@ -140,4 +140,35 @@ srtop.reveal('.work .box',{interval: 200});
 
 /* SCROLL EXPERIENCE */
 srtop.reveal('.experience .timeline',{delay: 400});
-srtop.reveal('.experience .timeline .container',{interval: 400}); 
+srtop.reveal('.experience .timeline .container',{interval: 400});
+
+// Fetch and render blog posts
+async function loadBlogPosts() {
+    const container = document.getElementById('blog-posts');
+    if (!container) return;
+    try {
+        const response = await fetch('https://api.github.com/repos/SamandeepSinghTomar/Portfolio_Website/issues?labels=blog&state=open');
+        if (!response.ok) throw new Error('Network response was not ok');
+        const posts = await response.json();
+        container.innerHTML = '';
+        if (posts.length === 0) {
+            container.innerHTML = '<p>No blog posts yet.</p>';
+            return;
+        }
+        posts.forEach(postData => {
+            const post = document.createElement('div');
+            post.className = 'blog-post';
+            const title = document.createElement('h3');
+            title.textContent = postData.title;
+            const body = document.createElement('div');
+            body.innerHTML = marked.parse(postData.body || '');
+            post.appendChild(title);
+            post.appendChild(body);
+            container.appendChild(post);
+        });
+    } catch (error) {
+        console.error('Error loading blog posts:', error);
+    }
+}
+
+window.addEventListener('DOMContentLoaded', loadBlogPosts);

--- a/index.html
+++ b/index.html
@@ -484,7 +484,6 @@
 <section id="blog" class="section">
     <h2 class="section-title">Blogs</h2>
     <div id="blog-posts">
-        <!-- Blog posts will be dynamically loaded here -->
     </div>
 </section>
 <!-- Blog Section Ends -->
@@ -558,6 +557,8 @@
   <!-- scroll reveal anim -->
   <script src="https://unpkg.com/scrollreveal"></script>
   <!-- ==== ALL MAJOR JAVASCRIPT CDNS ENDS ==== -->
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
   <script src="./assests/js/script.js"></script>
 


### PR DESCRIPTION
## Summary
- load blog posts dynamically from GitHub issues labeled `blog`
- render Markdown posts using marked.js
- remove mentions of the mechanism from the front end

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899747260fc83249b8228c55e513c92