### PR TITLE
Fix loader loop by cleaning dark mode toggle script

### DIFF
--- a/assests/js/script.js
+++ b/assests/js/script.js
@@ -177,17 +177,9 @@ window.addEventListener('DOMContentLoaded', loadBlogPosts);
 
 // dark mode toggle
 const themeToggle = document.getElementById('theme-toggle');
-if (themeToggle) {
-  const storedTheme = localStorage.getItem('theme');
-  if (storedTheme === 'dark') {
-    document.body.classList.add('dark-mode');
-    themeToggle.checked = true;
-  }
+const themeIcon = document.getElementById('theme-icon');
 
-  themeToggle.addEventListener('change', () => {
-    document.body.classList.toggle('dark-mode', themeToggle.checked);
-    localStorage.setItem('theme', themeToggle.checked ? 'dark' : 'light');
-  const themeIcon = document.getElementById('theme-icon');
+if (themeToggle && themeIcon) {
   const storedTheme = localStorage.getItem('theme');
   if (storedTheme === 'dark') {
     document.body.classList.add('dark-mode');

--- a/index.html
+++ b/index.html
@@ -46,11 +46,6 @@
   </header>
   <!-- navbar ends -->
 
-  <div class="theme-switch">
-    <input type="checkbox" id="theme-toggle" aria-label="Toggle dark mode">
-    <label for="theme-toggle"></label>
-  </div>
-
   <button id="theme-toggle" aria-label="Toggle dark mode">
     <i id="theme-icon" class="fas fa-moon"></i>
   </button>


### PR DESCRIPTION
## Summary
- remove duplicate theme switch markup
- simplify dark mode toggle script and ensure preloader runs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5529b7abc8324af6b90a8dc007c46