### PR TITLE
Add privacy lock overlay to gate portfolio behind a password

### DIFF
--- a/assests/css/style.css
+++ b/assests/css/style.css
@@ -44,6 +44,111 @@ body {
   line-height: 1.6;
 }
 
+body.is-locked {
+  overflow: hidden;
+}
+
+#page-content {
+  transition: filter 0.3s ease;
+}
+
+body.is-locked #page-content {
+  filter: blur(8px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.privacy-lock {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20000;
+  padding: 2.4rem;
+}
+
+.privacy-lock.is-hidden {
+  display: none;
+}
+
+.privacy-lock__panel {
+  background: var(--surface);
+  color: var(--text-color);
+  width: min(420px, 100%);
+  border-radius: 2rem;
+  padding: 3rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.privacy-lock__icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--heading-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.privacy-lock__panel h2 {
+  font-size: 2.4rem;
+  margin-bottom: 0.6rem;
+  color: var(--heading-color);
+}
+
+.privacy-lock__panel p {
+  font-size: 1.4rem;
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.privacy-lock__form {
+  display: grid;
+  gap: 1.2rem;
+  text-align: left;
+}
+
+.privacy-lock__label {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--heading-color);
+}
+
+.privacy-lock__form input {
+  padding: 1rem 1.2rem;
+  border-radius: 1.2rem;
+  border: 1px solid var(--border);
+  font-size: 1.4rem;
+  font-family: inherit;
+}
+
+.privacy-lock__button {
+  background: var(--heading-accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 1rem 1.4rem;
+  font-size: 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.privacy-lock__button:hover {
+  background: #1d4ed8;
+}
+
+.privacy-lock__error {
+  font-size: 1.2rem;
+  color: #dc2626;
+  min-height: 1.6rem;
+}
+
 html::-webkit-scrollbar {
   width: 0.8rem;
 }

--- a/assests/js/script.js
+++ b/assests/js/script.js
@@ -196,3 +196,48 @@ if (themeToggle && themeIcon) {
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   });
 }
+
+const lockOverlay = document.getElementById('privacy-lock');
+const lockForm = document.getElementById('privacy-lock-form');
+const lockInput = document.getElementById('privacy-password');
+const lockError = document.getElementById('privacy-lock-error');
+const requiredPassword = 'drowssap';
+
+function unlockPortfolio() {
+  document.body.classList.remove('is-locked');
+  if (lockOverlay) {
+    lockOverlay.classList.add('is-hidden');
+  }
+  sessionStorage.setItem('portfolioUnlocked', 'true');
+}
+
+function lockPortfolio() {
+  document.body.classList.add('is-locked');
+  if (lockOverlay) {
+    lockOverlay.classList.remove('is-hidden');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!lockOverlay || !lockForm || !lockInput) return;
+  if (sessionStorage.getItem('portfolioUnlocked') === 'true') {
+    unlockPortfolio();
+    return;
+  }
+  lockPortfolio();
+  lockInput.focus();
+  lockForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const entered = lockInput.value.trim();
+    if (entered === requiredPassword) {
+      lockInput.value = '';
+      if (lockError) lockError.textContent = '';
+      unlockPortfolio();
+      return;
+    }
+    if (lockError) {
+      lockError.textContent = 'Incorrect password. Please try again.';
+    }
+    lockInput.select();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -31,6 +31,25 @@
     </div>
   </div>
 
+  <div id="privacy-lock" class="privacy-lock" role="dialog" aria-modal="true" aria-labelledby="privacy-lock-title">
+    <div class="privacy-lock__panel">
+      <div class="privacy-lock__icon" aria-hidden="true">
+        <i class="fas fa-lock"></i>
+      </div>
+      <h2 id="privacy-lock-title">Locked for privacy</h2>
+      <p>Enter the password to unlock this portfolio.</p>
+      <form id="privacy-lock-form" class="privacy-lock__form">
+        <label class="privacy-lock__label" for="privacy-password">Password</label>
+        <input id="privacy-password" type="password" placeholder="Enter password" autocomplete="current-password"
+          required>
+        <button type="submit" class="privacy-lock__button">Unlock</button>
+        <p id="privacy-lock-error" class="privacy-lock__error" aria-live="polite"></p>
+      </form>
+    </div>
+  </div>
+
+  <div id="page-content">
+
   <!-- navbar starts -->
   <header>
     <a href="/Portfolio-Website" class="logo"> Samandeep</a>
@@ -536,6 +555,7 @@
   <a href="#home" class="fas fa-angle-up" id="scroll-top"></a>
   <!-- scroll back to top -->
 
+  </div>
 
   <!-- ==== ALL MAJOR JAVASCRIPT CDNS STARTS ==== -->
   <!-- jquery cdn -->


### PR DESCRIPTION
### Motivation
- Provide a simple privacy layer that prevents casual viewers from seeing the portfolio until a password is entered.
- Keep the existing site structure and appearance intact while adding an opt-in unlock flow.

### Description
- Added a modal overlay and wrapper around the main content in `index.html` to present a password prompt (markup inserted: `#privacy-lock` and `#page-content`).
- Implemented styles in `assests/css/style.css` to blur and disable interaction with the page when locked and to style the lock panel and error state.
- Added client-side logic to `assests/js/script.js` that enforces the lock, checks the password (`drowssap`), hides the overlay on success, and stores an unlocked flag in `sessionStorage`.
- Included basic accessibility attributes on the overlay such as `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` for improved screen-reader behavior.